### PR TITLE
fix extraneous braces around hyphen in first name

### DIFF
--- a/abbrev.bibyml
+++ b/abbrev.bibyml
@@ -3677,7 +3677,7 @@ eurocrypt:
         name1:          eurocryptname # "~2017, Part~I"
         name2:          eurocryptname # "~2017, Part~II"
         name3:          eurocryptname # "~2017, Part~III"
-        ed:             "Jean{-}S{\'{e}}bastien Coron and Jesper Buus Nielsen"
+        ed:             "Jean-S{\'{e}}bastien Coron and Jesper Buus Nielsen"
         vol1:           "10210"
         vol2:           "10211"
         vol3:           "10212"


### PR DESCRIPTION
compound hyphenated first names are not recognized as compounds if the hyphen is entered as {-}. This gets in the way with styles that want to abbreviate them as compounds, as in Jean-Paul -> J.-P. (which, to most styles, is _the_ correct way to abbreviate, but this is another story. As far as the db is concerned, what we want to do is only to have the source information correct).

reported by Paul Zimmermann