### PR TITLE
Switch IACR eprint and ToSC URLs from HTTP to HTTPS

### DIFF
--- a/crypto_misc.bib
+++ b/crypto_misc.bib
@@ -4050,7 +4050,7 @@ year =           1997,
   title =        "{ISO 18033-2}: An Emerging Standard for Public-Key Encryption",
   month =        dec,
   year =         2004,
-  howpublished = "\url{http://shoup.net/iso/std6.pdf}",
+  howpublished = "\url{https://shoup.net/iso/std6.pdf}",
   note =         "Final Committee Draft",
 }
 

--- a/crypto_misc.bib
+++ b/crypto_misc.bib
@@ -1834,7 +1834,7 @@ year =           1997,
   volume =       "E85-A",
   number =       10,
   month =        oct,
-  note =         "Also available at \url{http://eprint.iacr.org/2003/038/}",
+  note =         "Also available at \url{https://eprint.iacr.org/2003/038/}",
 }
 
 @Article{IEICE:MitSakKas02,


### PR DESCRIPTION
I used

```bash
sed -i 's|http://eprint|https://eprint|g' crypto_*.bib
sed -i 's|http://tosc|https://tosc|g' crypto_*.bib
```

to produce these changes. The command

```bash
grep -ri "http://" .
```

yields 28 remaining HTTP URLs. They are either broken (HTTP Status Code 404), or do not have a valid HTTPS certificate, or are websites of organizations (compared to DOIs of papers), so I did not want to spend more time on them. Except for the shoup.net URL, because I recognized it ;)