### PR TITLE
Fix Latincrypt 2017 proceedings year

### DIFF
--- a/crypto_conf_list.bib
+++ b/crypto_conf_list.bib
@@ -10093,7 +10093,7 @@
   address =      latincrypt17addr,
   publisher =    latincryptpub,
   series =       mylncs,
-  year =         2017,
+  year =         2019,
 }
 
 @Proceedings{LC15,


### PR DESCRIPTION
The Latincrypt 2017 proceedings came out in 2019. The `month` field
still references the actual event, however... How should this be
reconciled?

See also #170 