### PR TITLE
Update links to NISTPQC Round {1,2,3}

### DIFF
--- a/crypto_misc.bib
+++ b/crypto_misc.bib
@@ -80,7 +80,7 @@
   title        = {{Classic McEliece}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-3-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-3-submissions}},
 }
 
 @techreport{NISTPQC-R3:CRYSTALS-KYBER20,
@@ -88,7 +88,7 @@
   title        = {{CRYSTALS-KYBER}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-3-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-3-submissions}},
 }
 
 @techreport{NISTPQC-R3:NTRU20,
@@ -96,7 +96,7 @@
   title        = {{NTRU}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-3-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-3-submissions}},
 }
 
 @techreport{NISTPQC-R3:SABER20,
@@ -104,7 +104,7 @@
   title        = {{SABER}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-3-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-3-submissions}},
 }
 
 % ============= Finalists: SIGNATURE
@@ -113,7 +113,7 @@
   title        = {{CRYSTALS-DILITHIUM}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-3-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-3-submissions}},
 }
 
 @techreport{NISTPQC-R3:FALCON20,
@@ -121,7 +121,7 @@
   title        = {{FALCON}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-3-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-3-submissions}},
 }
 
 @techreport{NISTPQC-R3:Rainbow20,
@@ -129,7 +129,7 @@
   title        = {{Rainbow}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-3-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-3-submissions}},
 }
 
 % ============= Alternate Candidates: PKE/KEM
@@ -138,7 +138,7 @@
   title        = {{BIKE}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-3-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-3-submissions}},
 }
 
 @techreport{NISTPQC-R3:FrodoKEM20,
@@ -146,7 +146,7 @@
   title        = {{FrodoKEM}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-3-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-3-submissions}},
 }
 
 @techreport{NISTPQC-R3:HQC20,
@@ -154,7 +154,7 @@
   title        = {{HQC}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-3-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-3-submissions}},
 }
 
 @techreport{NISTPQC-R3:NTRUPrime20,
@@ -164,7 +164,7 @@
   title        = {{NTRU Prime}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-3-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-3-submissions}},
 }
 
 @techreport{NISTPQC-R3:SIKE20,
@@ -172,7 +172,7 @@
   title        = {{SIKE}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-3-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-3-submissions}},
 }
 
 % ============= Alternate Candidates: SIGNATURE
@@ -181,7 +181,7 @@
   title        = {{GeMSS}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-3-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-3-submissions}},
 }
 
 @techreport{NISTPQC-R3:Picnic20,
@@ -189,7 +189,7 @@
   title        = {{Picnic}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-3-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-3-submissions}},
 }
 
 @techreport{NISTPQC-R3:SPHINCS+20,
@@ -197,7 +197,7 @@
   title        = {{SPHINCS+}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-3-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-3-submissions}},
 }
 
 %------------------------------------------------------------------
@@ -209,7 +209,7 @@
   title        = {{BIKE}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:ClassicMcEliece19,
@@ -217,7 +217,7 @@
   title        = {{Classic McEliece}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:CRYSTALS-KYBER19,
@@ -225,7 +225,7 @@
   title        = {{CRYSTALS-KYBER}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:FrodoKEM19,
@@ -233,7 +233,7 @@
   title        = {{FrodoKEM}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:HQC19,
@@ -241,7 +241,7 @@
   title        = {{HQC}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:LAC19,
@@ -249,7 +249,7 @@
   title        = {{LAC}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:LEDAcrypt19,
@@ -257,7 +257,7 @@
   title        = {{LEDAcrypt}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:NewHope19,
@@ -265,7 +265,7 @@
   title        = {{NewHope}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:NTRU19,
@@ -273,7 +273,7 @@
   title        = {{NTRUEncrypt}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:NTRUPrime19,
@@ -281,7 +281,7 @@
   title        = {{NTRU Prime}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:NTS-KEM19,
@@ -289,7 +289,7 @@
   title        = {{NTS-KEM}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:ROLLO19,
@@ -297,7 +297,7 @@
   title        = {{ROLLO}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:Round519,
@@ -305,7 +305,7 @@
   title        = {{Round5}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:RQC19,
@@ -313,7 +313,7 @@
   title        = {{RQC}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:SABER19,
@@ -321,7 +321,7 @@
   title        = {{SABER}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:SIKE19,
@@ -329,7 +329,7 @@
   title        = {{SIKE}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:ThreeBears19,
@@ -337,7 +337,7 @@
   title        = {{Three Bears}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 
@@ -347,7 +347,7 @@
   title        = {{CRYSTALS-DILITHIUM}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:FALCON19,
@@ -355,7 +355,7 @@
   title        = {{FALCON}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:GeMSS19,
@@ -363,7 +363,7 @@
   title        = {{GeMSS}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:LUOV19,
@@ -371,7 +371,7 @@
   title        = {{LUOV}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:MQDSS19,
@@ -379,7 +379,7 @@
   title        = {{MQDSS}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:Picnic19,
@@ -387,7 +387,7 @@
   title        = {{Picnic}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:qTESLA19,
@@ -395,7 +395,7 @@
   title        = {{qTESLA}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:Rainbow19,
@@ -403,7 +403,7 @@
   title        = {{Rainbow}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 @techreport{NISTPQC-R2:SPHINCS+19,
@@ -411,7 +411,7 @@
   title        = {{SPHINCS+}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-2-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-2-submissions}},
 }
 
 %------------------------------------------------------------------
@@ -423,7 +423,7 @@
   title        = {{BIG QUAKE}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:BIKE17,
@@ -431,7 +431,7 @@
   title        = {{BIKE}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:CFPKM17,
@@ -439,7 +439,7 @@
   title        = {{CFPKM}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:ClassicMcEliece17,
@@ -447,7 +447,7 @@
   title        = {{Classic McEliece}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:CompactLWE17,
@@ -455,7 +455,7 @@
   title        = {{Compact LWE}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:CRYSTALS-DILITHIUM17,
@@ -463,7 +463,7 @@
   title        = {{CRYSTALS-DILITHIUM}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:CRYSTALS-KYBER17,
@@ -471,7 +471,7 @@
   title        = {{CRYSTALS-KYBER}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:DAGS17,
@@ -479,7 +479,7 @@
   title        = {{DAGS}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:DingKeyExchange17,
@@ -487,7 +487,7 @@
   title        = {{Ding Key Exchange}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:DME17,
@@ -495,7 +495,7 @@
   title        = {{DME}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:DRS17,
@@ -503,7 +503,7 @@
   title        = {{DRS}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:DualModeMS17,
@@ -511,7 +511,7 @@
   title        = {{DualModeMS}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:Edon-K17,
@@ -519,7 +519,7 @@
   title        = {{Edon-K}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:EMBLEMandR.EMBLEM17,
@@ -527,7 +527,7 @@
   title        = {{EMBLEM and R.EMBLEM}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:FALCON17,
@@ -535,7 +535,7 @@
   title        = {{FALCON}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:FrodoKEM17,
@@ -543,7 +543,7 @@
   title        = {{FrodoKEM}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:GeMSS17,
@@ -551,7 +551,7 @@
   title        = {{GeMSS}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:Giophantus17,
@@ -559,7 +559,7 @@
   title        = {{Giophantus}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:Gravity-SPHINCS17,
@@ -567,7 +567,7 @@
   title        = {{Gravity-SPHINCS}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:GuessAgain17,
@@ -575,7 +575,7 @@
   title        = {{Guess Again}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:Gui17,
@@ -583,7 +583,7 @@
   title        = {{Gui}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:HILA517,
@@ -591,7 +591,7 @@
   title        = {{HILA5}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:HiMQ-317,
@@ -599,7 +599,7 @@
   title        = {{HiMQ-3}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:HK1717,
@@ -607,7 +607,7 @@
   title        = {{HK17}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:HQC17,
@@ -615,7 +615,7 @@
   title        = {{HQC}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:KCL17,
@@ -623,7 +623,7 @@
   title        = {{KCL (pka OKCN/AKCN/CNKE)}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:KINDI17,
@@ -631,7 +631,7 @@
   title        = {{KINDI}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:LAC17,
@@ -639,7 +639,7 @@
   title        = {{LAC}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:LAKE17,
@@ -647,7 +647,7 @@
   title        = {{LAKE}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:LEDAkem17,
@@ -655,7 +655,7 @@
   title        = {{LEDAkem}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:LEDApkc17,
@@ -663,7 +663,7 @@
   title        = {{LEDApkc}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:Lepton17,
@@ -671,7 +671,7 @@
   title        = {{Lepton}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:LIMA17,
@@ -679,7 +679,7 @@
   title        = {{LIMA}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:Lizard17,
@@ -687,7 +687,7 @@
   title        = {{Lizard}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:LOCKER17,
@@ -695,7 +695,7 @@
   title        = {{LOCKER}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:LOTUS17,
@@ -703,7 +703,7 @@
   title        = {{LOTUS}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:LUOV17,
@@ -711,7 +711,7 @@
   title        = {{LUOV}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:McNie17,
@@ -719,7 +719,7 @@
   title        = {{McNie}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:Mersenne-75683917,
@@ -727,7 +727,7 @@
   title        = {{Mersenne-756839}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:MQDSS17,
@@ -735,7 +735,7 @@
   title        = {{MQDSS}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:NewHope17,
@@ -743,7 +743,7 @@
   title        = {{NewHope}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:NTRUEncrypt17,
@@ -751,7 +751,7 @@
   title        = {{NTRUEncrypt}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:pqNTRUSign17,
@@ -759,7 +759,7 @@
   title        = {{pqNTRUSign}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:NTRU-HRSS-KEM17,
@@ -767,7 +767,7 @@
   title        = {{NTRU-HRSS-KEM}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:NTRUPrime17,
@@ -775,7 +775,7 @@
   title        = {{NTRU Prime}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:NTS-KEM17,
@@ -783,7 +783,7 @@
   title        = {{NTS-KEM}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:OddManhattan17,
@@ -791,7 +791,7 @@
   title        = {{Odd Manhattan}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:Ouroboros-R17,
@@ -799,7 +799,7 @@
   title        = {{Ouroboros-R}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:Picnic17,
@@ -807,7 +807,7 @@
   title        = {{Picnic}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:Post-quantumRSA-Encryption17,
@@ -815,7 +815,7 @@
   title        = {{Post-quantum RSA-Encryption}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:Post-quantumRSA-Signature17,
@@ -823,7 +823,7 @@
   title        = {{Post-quantum RSA-Signature}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:pqsigRM17,
@@ -831,7 +831,7 @@
   title        = {{pqsigRM}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:QC-MDPCKEM17,
@@ -839,7 +839,7 @@
   title        = {{QC-MDPC KEM}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:qTESLA17,
@@ -847,7 +847,7 @@
   title        = {{qTESLA}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:RaCoSS17,
@@ -855,7 +855,7 @@
   title        = {{RaCoSS}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:Rainbow17,
@@ -863,7 +863,7 @@
   title        = {{Rainbow}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:Ramstake17,
@@ -871,7 +871,7 @@
   title        = {{Ramstake}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:RankSign17,
@@ -879,7 +879,7 @@
   title        = {{RankSign}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:RLCE-KEM17,
@@ -887,7 +887,7 @@
   title        = {{RLCE-KEM}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:Round217,
@@ -895,7 +895,7 @@
   title        = {{Round2}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:RQC17,
@@ -903,7 +903,7 @@
   title        = {{RQC}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:RVB17,
@@ -911,7 +911,7 @@
   title        = {{RVB}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:SABER17,
@@ -919,7 +919,7 @@
   title        = {{SABER}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:SIKE17,
@@ -927,7 +927,7 @@
   title        = {{SIKE}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:SPHINCS+17,
@@ -935,7 +935,7 @@
   title        = {{SPHINCS+}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:SRTPI17,
@@ -943,7 +943,7 @@
   title        = {{SRTPI}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:ThreeBears17,
@@ -951,7 +951,7 @@
   title        = {{Three Bears}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:Titanium17,
@@ -959,7 +959,7 @@
   title        = {{Titanium}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 @techreport{NISTPQC-R1:WalnutDSA17,
@@ -967,7 +967,7 @@
   title        = {{WalnutDSA}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
-  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/round-1-submissions}},
+  note         = {available at \url{https://csrc.nist.gov/projects/post-quantum-cryptography/post-quantum-cryptography-standardization/round-1-submissions}},
 }
 
 %------------------------------------------------------------------


### PR DESCRIPTION
All the links to the old NIST PQC rounds 1,2,3 are broken. They require `.../post-quantum-cryptography-standardization/...` in the URL. However, `round-4-submissions` and `selected-algorithms-2022` are correct (for now).