### PR TITLE
Correct Matthias J. Kannwischer's name in Rainbow submission

### DIFF
--- a/crypto_misc.bib
+++ b/crypto_misc.bib
@@ -125,7 +125,7 @@
 }
 
 @techreport{NISTPQC-R3:Rainbow20,
-  author       = {Jintai Ding and Ming-Shing Chen and Albrecht Petzoldt and Dieter Schmidt and Bo-Yin Yang and Matthias Kannwischer and Jacques Patarin},
+  author       = {Jintai Ding and Ming-Shing Chen and Albrecht Petzoldt and Dieter Schmidt and Bo-Yin Yang and Matthias J. Kannwischer and Jacques Patarin},
   title        = {{Rainbow}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,


### PR DESCRIPTION
Matthias (@mkannwischer) spells his name as Matthias J. Kannwischer in all of his papers, e.g. https://eprint.iacr.org/2019/844