### PR TITLE
Added DOIs and months for JACM and CACM as well as fixed NoeLin98

### DIFF
--- a/crypto_misc.bib
+++ b/crypto_misc.bib
@@ -1708,9 +1708,12 @@
                   Yi-Bing Lin",
   title =        "Wireless Local Loop: Architecture, Technologies and Services",
   journal =      ieeepc,
+  volume =       5,
+  number =       3,
   year =         1998,
   pages =        "74--80",
   month =        jun,
+  doi =          "10.1109/98.683743",
 }
 
 %------------------------------------------------------------------

--- a/crypto_misc.bib
+++ b/crypto_misc.bib
@@ -1526,7 +1526,8 @@
   volume =       42,
   number =       6,
   pages =        "60--66",
-  month =        jun
+  month =        jun,
+  doi =          "10.1145/303849.303863",
 }
 
 @Article{DenSac81,
@@ -1538,6 +1539,8 @@
   number =       8,
   pages =        "533--536",
   year =         1981,
+  month =        aug,
+  doi =          "10.1145/358722.358740",
 }
 
 @Article{Lamport81,
@@ -1549,6 +1552,7 @@
   number =       11,
   pages =        "770--772",
   month =        dec,
+  doi =          "10.1145/358790.358797",
 }
 
 @Article{RivShaAdl78,
@@ -1563,7 +1567,7 @@
   journal =      cacm,
   volume =       21,
   number =       2,
-  doi =          {10.1145/359340.359342},
+  doi =          "10.1145/359340.359342",
 }
 
 @Article{Shamir79,
@@ -1575,6 +1579,7 @@
   pages =        "612--613",
   month =        nov,
   year =         1979,
+  doi =          "10.1145/359168.359176",
 }
 
 @Article{NeeSch78,
@@ -1586,7 +1591,8 @@
   pages =        "993--999",
   title =        "Using encryption for authentication in large networks of computers",
   volume =       21,
-  year =         1978
+  year =         1978,
+  doi =          "10.1145/359657.359659",
 }
 
 @Article{MBONE,
@@ -1597,7 +1603,8 @@
   pages =        "54--60",
   title =        "{MBone:} The Multicast Backbone",
   volume =       37,
-  year =         1994
+  year =         1994,
+  doi =          "10.1145/179606.179627",
 }
 
 %------------------------------------------------------------------
@@ -1611,9 +1618,11 @@
   pages =        "231--262",
   journal =      jacm,
   year =         2004,
+  month =        mar,
   volume =       51,
   number =       2,
   annote =       "Full version of \cite{FOCS:NaoRei97}",
+  doi =          "10.1145/972639.972643",
 }
 
 @Article{Feige98,
@@ -1622,8 +1631,10 @@
   pages =        "634--652",
   journal =      jacm,
   year =         1998,
+  month =        jul,
   volume =       45,
   number =       4,
+  doi =          "10.1145/285055.285059",
 }
 
 @Article{DDWY93,
@@ -1641,6 +1652,7 @@
   keywords =     "Algorithms; Distributed Communication; distributed
                  computing; fault-tolerance; perfectly secure
                  communication; Reliability; Security",
+  doi =          "10.1145/138027.138036",
 }
 
 @Article{BelMic92,
@@ -1652,7 +1664,9 @@
   volume =       39,
   number =       1,
   year =         1992,
+  month =        jan,
   annote =       "Full version of \cite{STOC:BelMic88}",
+  doi =          "10.1145/147508.147537",
 }
 
 @Article{GolMicWig91,
@@ -1663,9 +1677,11 @@
   pages =        "691--729",
   journal =      jacm,
   year =         1991,
+  month =        jul,
   volume =       38,
   number =       3,
   annote =       "Full version of \cite{FOCS:GolMicWig86}",
+  doi =          "10.1145/116825.116852",
 }
 
 @Article{GolGolMic86,
@@ -1680,6 +1696,7 @@
   month =        oct,
   year =         1986,
   annote =       "Full version of \cite{FOCS:GolGolMic84}",
+  doi =          "10.1145/6490.6503",
 }
 
 %------------------------------------------------------------------


### PR DESCRIPTION
These commits add missing DOIs for journal papers from Journal of the ACM as well as Communications of the ACM and missing volume/number information as well as DOI for NoeLin98.