### PR TITLE
Add ISBN values for some books.

### DIFF
--- a/crypto_misc.bib
+++ b/crypto_misc.bib
@@ -3668,17 +3668,20 @@ year =           1997,
   author =       "Jonathan Katz and
                   Yehuda Lindell",
   title =        "Introduction to Modern Cryptography",
-  publisher =    "{CRC} Press",
+  publisher =    "Chapman and Hall, {CRC} Press",
   year =         2014,
-  edition =      "Second",
+  edition =      "Third",
+  isbn =         "978-0815354369",
 }
 
 @Book{KatLin07,
   author =       "Jonathan Katz and
                   Yehuda Lindell",
   title =        "Introduction to Modern Cryptography",
-  publisher =    "Chapman and Hall/CRC Press",
+  publisher =    "Chapman and Hall/{CRC} Press",
   year =         2007,
+  edition =      "First",
+  isbn =         "978-1584885511",
 }
 
 @Book{FosKes04,
@@ -3687,6 +3690,7 @@ year =           1997,
   title =        "The Grid 2: Blueprint for a New Computing Infrastructure",
   publisher =    "Morgan Kaufmann",
   year =         2004,
+  isbn =         "978-1558609334",
 }
 
 @Book{Goldreich04,
@@ -3696,7 +3700,8 @@ year =           1997,
   address =      "Cambridge, UK",
   volume =        2,
   year =         2004,
-  ISBN =         "ISBN 0-521-83084-2 (hardback)",
+  ISBN =         "978-0511721656",
+  doi =          "10.1017/CBO9780511721656",
 }
 
 @Book{Goldreich01,
@@ -3707,7 +3712,8 @@ year =           1997,
   volume =        1,
   pages =        "xix + 372",
   year =         2001,
-  ISBN =         "0-521-79172-3 (hardback)",
+  ISBN =         "978-0511546891",
+  doi =          "10.1017/CBO9780511546891",
   LCCN =         "QA268.G5745 2001",
   bibdate =      "Wed Jan 16 10:57:08 2002",
 }
@@ -3717,7 +3723,8 @@ year =           1997,
   title =        "Programming With {Qt}, Second Edition: Writing Portable {GUI} applications on {UNIX} and {Win32}",
   publisher =    "O'Reilly \& Associates, Inc.",
   month =        mar,
-  year =         2002
+  year =         2002,
+  isbn =         "978-0596000646",
 }
 
 @Book{Dalheimer99,
@@ -3725,7 +3732,8 @@ year =           1997,
   title =        "Programming With {Qt}: Writing Portable {GUI} applications on {UNIX} and {Win32}",
   publisher =    "O'Reilly \& Associates, Inc.",
   month =        apr,
-  year =         1999
+  year =         1999,
+  isbn =         "978-1565925885",
 }
 
 @Book{Freiss98,
@@ -3733,7 +3741,8 @@ year =           1997,
   title =        "Protecting Networks with {SATAN}",
   publisher =    "O'Reilly \& Associates, Inc.",
   month =        may,
-  year =         1998
+  year =         1998,
+  isbn =         "978-1565924253",
 }
 
 @Book{WalCav98,
@@ -3742,7 +3751,8 @@ year =           1997,
   title =        "Computer Security Policies and {SunScreen} Firewalls",
   key =          "Sun",
   publisher =    "Sun Microsystems Press",
-  year =         1998
+  year =         1998,
+  isbn =         "978-0130960153",
 }
 
 @Book{Diestel97,
@@ -3752,7 +3762,21 @@ year =           1997,
   year =         1997,
   address =      "New York, NY",
   note =         "Translated from the 1996 German original",
-  pages =        "xiv+289",
+  pages =        "xiv+289"
+
+}
+
+@Book{Diestel17,
+  author =       "Reinhard Diestel",
+  title =        "Graph theory",
+  publisher =    springer,
+  year =         2024,
+  edition =      "Sixth",
+  address =      "New York, NY",
+  note =         "Translated from the 1996 German original",
+  pages =        "469",
+  isbn =         "978-3-662-53621-6",
+
 }
 
 @Book{MenVanVan97,
@@ -3779,7 +3803,8 @@ year =           1997,
   publisher =    "Wiley Computer Publishing",
   pages =        "368",
   month =        jul,
-  year =         1997
+  year =         1997,
+  isbn =         "978-0471181484",
 }
 
 @Book{ColDin96,
@@ -3788,9 +3813,21 @@ year =           1997,
   title =        "The {CRC} Handbook of Combinatorial Designs",
   publisher =    "CRC Press",
   address =      "2000 N.W. Corporate Blvd., Boca Raton, FL 33431-9868, USA",
-  edition =      "Fifth",
-  pages =        753,
+  pages =        784,
   year =         1996,
+  isbn =         "978-0849389481",
+}
+
+@Book{ColDin06,
+  editor =       "Charles J. Colbourn and
+                  Jeffrey Dinitz",
+  title =        "The {CRC} Handbook of Combinatorial Designs",
+  publisher =    "CRC Press",
+  address =      "2000 N.W. Corporate Blvd., Boca Raton, FL 33431-9868, USA",
+  edition =      "Second",
+  pages =        1016,
+  year =         2006,
+  isbn =         "978-1584885061",
 }
 
 @Book{Luby96,
@@ -3803,14 +3840,18 @@ year =           1997,
   series =       "Princeton computer science notes",
   keywords =     "random number generators; computational complexity;
                  data encryption (computer science); numbers, random",
+  isbn =         "978-0691025469"
 }
 
 @Book{McCormac96,
   author =       "J. McCormac",
   title =        "European Scrambling Systems 5",
-  year =         1996,
+  year =         1994,
+  pages =        560,
+  edition =      "Fourth",
   publisher =    "Waterford University Press",
-  address =      "Waterford, Ireland"
+  address =      "Waterford, Ireland",
+  isbn =         "978-1873556030",
 }
 
 @Book{MenVanVan96,
@@ -3820,7 +3861,8 @@ year =           1997,
   title =        "Handbook of Applied Cryptography",
   publisher =    "CRC Press",
   year =         1996,
-  address =      "Boca Raton, Florida"
+  address =      "Boca Raton, Florida",
+  isbn =         "978-0849385230",
 }
 
 @Book{schneier96,
@@ -3829,7 +3871,9 @@ year =           1997,
   year =         1996,
   edition =      "Second",
   publisher =    "John Wiley \& Sons",
-  address =      "New York"
+  address =      "New York",
+  isbn =         "978-0471117094",
+  pages =        "758",
 }
 
 @Book{ChaZwi95,
@@ -3838,6 +3882,19 @@ year =           1997,
   title =        "Building {Internet} Firewalls",
   publisher =    "O'Reilly \& Associates, Inc.",
   year =         1995,
+  pages =        "544",
+  isbn =         "978-1565921245",
+}
+
+@Book{ChaZwi00,
+  author =       "D. Brent Chapman and
+                  Elizabeth D. Zwicky",
+  title =        "Building {Internet} Firewalls",
+  publisher =    "O'Reilly \& Associates, Inc.",
+  edition =      "Second",
+  pages =        "894",
+  year =         2000,
+  isbn =         "978-1565928718",
 }
 
 @Book{Hochbaum95,
@@ -3846,6 +3903,8 @@ year =           1997,
   publisher =    "PWS Publishing Company",
   address =      "Boston, MA",
   year =         1995,
+  pages =        "624",
+  isbn =         "978-0534949686",
 }
 
 @Book{CheBel94,
@@ -3853,14 +3912,25 @@ year =           1997,
                   S. M. Bellovin",
   title =        "Firewalls and {Internet} Security: Repelling the   Wily Hacker",
   publisher =    "Addison-Wesley",
-  year =         1994
+  year =         1994,
+  isbn =         "978-0201633573",
 }
 
 @Book{Stevens94,
   author =       "W. R. Stevens",
   title =        "{TCP/IP} Illustrated, Volume 1: The Protocols",
   publisher =    "Addison-Wesley",
-  year =         1994
+  year =         1994,
+  isbn =         "0-201-63346-9",
+}
+
+@Book{Stevens11,
+  author =       "W. R. Stevens",
+  title =        "{TCP/IP} Illustrated, Volume 1: The Protocols",
+  publisher =    "Addison-Wesley",
+  edition =      "Second",
+  year =         2011,
+  isbn =         "978-0321336316",
 }
 
 @Book{AhuMagOrl93,
@@ -3870,7 +3940,8 @@ year =           1997,
   title =        "Network Flows: Theory, Algorithms, and Applications",
   publisher =    "Prentice-Hall",
   year =         1993,
-  address =      "Upper Saddle River, NJ"
+  address =      "Upper Saddle River, NJ",
+  isbn =         "978-0136175490",
 }
 
 @Book{DuHwa93,
@@ -3879,6 +3950,8 @@ year =           1997,
   title =        "Combinatorial group testing and its Applications",
   publisher =    "World Scientific",
   year =         "1993",
+  doi =          "10.1142/4252",
+  isbn =         "978-9810241070",
 }
 
 @Book{AloSpe92,
@@ -3888,6 +3961,7 @@ year =           1997,
   publisher =    "Wiley-Interscience Publication",
   year =         1992,
   address =      "New York, NY",
+  isbn =         "978-0471535881",
 }
 
 @Book{Jain91,
@@ -3895,7 +3969,9 @@ year =           1997,
   title =        "The Art of Computer Systems Performance Analysis",
   publisher =    "John Wiley \& Sons",
   address =      "New York",
-  year =         1991
+  year =         1991,
+  pages =        "720",
+  isbn =         "978-0471503361",
 }
 
 @Book{LawKel91,
@@ -3904,15 +3980,18 @@ year =           1997,
   title =        "Simulation Modelling and Analysis",
   publisher =    "McGraw-Hill",
   year =         1991,
-  edition =      "2nd"
+  edition =      "2nd",
+  pages =        "544",
+  isbn =         "978-0070366985",
 }
 
 @Book{Ha90,
-  author =       "T. T. Ha",
+  author =       "Tri T. Ha",
   title =        "Digital Satellite Communications",
   publisher =    "McGraw-Hill",
   year =         1990,
-  edition =      "second"
+  edition =      "second",
+  isbn =         "978-0070253896"
 }
 
 @Book{CorLeiRiv90,
@@ -3922,13 +4001,15 @@ year =           1997,
   title =        "Introduction to Algorithms",
   publisher =    "McGraw-Hill",
   year =         1990,
+  isbn =         "0-262-03141-8",
 }
 
 @Book{Wegener87,
   author =       "I. Wegener",
   title =        "The Complexity of Boolean Functions",
   publisher =    "Wiley",
-  year =         1987
+  year =         1987,
+  isbn =         "978-0471915553",
 }
 
 @Book{GarJoh79,
@@ -3939,6 +4020,7 @@ year =           1997,
   publisher =    {Freeman},
   address =      {San Francisco},
   year =         1979,
+  isbn =         "0-7167-1045-5",
 }
 
 @Book{BirMac77,
@@ -3948,6 +4030,7 @@ year =           1997,
   edition =      {4th},
   publisher =    {Macmillan Publishing Co.},
   year =         1977,
+  isbn =         "978-0023100703"
 }
 
 @Book{MacSlo77,
@@ -3956,6 +4039,7 @@ year =           1997,
   title =        {The Theory of Error Correcting Codes},
   publisher =    {North Holland},
   year =         1977,
+  isbn =         "978-0444850102",
 }
 
 @Book{Golomb67,
@@ -3965,17 +4049,7 @@ year =           1997,
   address =       {San Francisco},
   year =          1967,
   note =          {Reprinted by Aegean Park Press, 1982},
-}
-
-@Book{CompGrid,
-  author =       "Ian T. Foster and
-                  Carl Kesselman",
-  title =        "The Grid: Blueprint for a New Computing Infrastructure",
-  publisher =    "Morgan Kaufmann Publishers, Inc.",
-  address =      "",
-  volume =       "",
-  pages =        "",
-  year =         1998,
+  isbn =          {978-0894120480},
 }
 
 @Book{Smart16,


### PR DESCRIPTION
It turns out that we need ISBN values for bibliographic references when we report citations to crossref. I added a few here. There was a duplicate (CompGrid was a duplicate of FosKes04).