### PR TITLE
Various name fixes, in particular regarding von-prefix (prelast) & lineage (Jr./Sr./I/II/III/IV/V)

### DIFF
--- a/abbrev.bibyml
+++ b/abbrev.bibyml
@@ -1073,7 +1073,7 @@ acns:
         name:
             @0:         "ACNS 13: 11th " # acnsname
             @2:         "ACNS 13" # acnsname
-        ed:             "Michael J. {Jacobson Jr.} and Michael E. Locasto and Payman Mohassel and Reihaneh Safavi-Naini"
+        ed:             "Jacobson, Jr., Michael J. and Michael E. Locasto and Payman Mohassel and Reihaneh Safavi-Naini"
         vol:            "7954"
         addr:
             @0:         "Banff, AB, Canada"
@@ -2810,7 +2810,7 @@ ches:
     02:                 "CHES02"
         key:            "CHES 2002"
         name:           chesname # "~2002"
-        ed:             "Burton S. {Kaliski Jr.} and {\c{C}etin Kaya} Ko\c{c} and Christof Paar"
+        ed:             "Kaliski, Jr., Burton S. and {\c{C}etin Kaya} Ko\c{c} and Christof Paar"
         vol:            "2523"
         addr:
             @0:         "Redwood Shores, CA, USA"
@@ -3359,7 +3359,7 @@ crypto:
     97:                 "C97"
         key:            "CRYPTO 1997"
         name:           cryptoname # "'97"
-        ed:             "Burton S. {Kaliski Jr.}"
+        ed:             "Kaliski, Jr., Burton S."
         vol:            "1294"
         month:
             @0:         aug # "~17--21,"
@@ -10978,7 +10978,7 @@ pets:
         name:
             @0:         "PET~2004: 4th " # petsname_v1
             @2:         "PET~2004" # petsname_v1
-        ed:             "David M. {Martin Jr.} and Andrei Serjantov"
+        ed:             "Martin, Jr., David M. and Andrei Serjantov"
         vol:            "3424"
         addr:
             @0:         "Toronto, Canada"
@@ -10992,7 +10992,7 @@ pets:
         name:
             @0:         "PET~2005: 5th " # petsname_v1
             @2:         "PET~2005" # petsname_v1
-        ed:             "George Danezis and David M. {Martin Jr.}"
+        ed:             "George Danezis and Martin, Jr., David M."
         vol:            "3856"
         addr:
             @0:         "Cavtat, Croatia"
@@ -12554,7 +12554,7 @@ sac:
         name:
             @0:         "SAC 2009: 16th " # sacname
             @2:         "SAC 2009" # sacname
-        ed:             "Michael J. {Jacobson Jr.} and Vincent Rijmen and Reihaneh Safavi-Naini"
+        ed:             "Jacobson, Jr., Michael J. and Vincent Rijmen and Reihaneh {Safavi-Naini}"
         vol:            "5867"
         addr:
             @0:         "Calgary, Alberta, Canada"
@@ -12680,7 +12680,7 @@ sac:
         name:
             @0:         "SAC 2018: 25th " # sacname
             @2:         "SAC 2018" # sacname
-        ed:             "Carlos Cid and Michael J. {Jacobson Jr}:"
+        ed:             "Carlos Cid and Jacobson, Jr., Michael J.:"
         vol:            "11349"
         addr:
             @0:         "Calgary, AB, Canada"
@@ -12708,7 +12708,7 @@ sac:
         name:
             @0:         "SAC 2020: 27th " # sacname
             @2:         "SAC 2020" # sacname
-        ed:             "Orr Dunkelman and Michael J. Jacobson Jr. and Colin O'Flynn"
+        ed:             "Orr Dunkelman and Jacobson, Jr., Michael J. and Colin O'Flynn"
         vol:            "12804"
         addr:
             @0:         "Halifax, NS, Canada (Virtual Event)"

--- a/abbrev.bibyml
+++ b/abbrev.bibyml
@@ -4233,7 +4233,7 @@ esorics:
         name:
             @0:         "ESORICS~2005: 10th " # esoricsname
             @2:         "ESORICS~2005" # esoricsname
-        ed:             "Sabrina De Capitani {di Vimercati} and Paul F. Syverson and Dieter Gollmann"
+        ed:             "Sabrina {De Capitani di Vimercati} and Paul F. Syverson and Dieter Gollmann"
         vol:            "3679"
         addr:
             @0:         "Milan, Italy"
@@ -4775,7 +4775,7 @@ eurocrypt:
     94:                 "EC94"
         key:            "EUROCRYPT 1994"
         name:           eurocryptname # "'94"
-        ed:             "Alfredo De Santis"
+        ed:             "Alfredo {De Santis}"
         vol:            "950"
         addr:
             @0:         "Perugia, Italy"
@@ -12850,7 +12850,7 @@ scn:
         name:
             @0:         "SCN 06: 5th " # scnname
             @2:         "SCN 06" # scnname
-        ed:             "Roberto De Prisco and Moti Yung"
+        ed:             "Roberto {De Prisco} and Moti Yung"
         vol:            "4116"
         addr:
             @0:         "Maiori, Italy"
@@ -12864,7 +12864,7 @@ scn:
         name:
             @0:         "SCN 08: 6th " # scnname
             @2:         "SCN 08" # scnname
-        ed:             "Rafail Ostrovsky and Roberto De Prisco and Ivan Visconti"
+        ed:             "Rafail Ostrovsky and Roberto {De Prisco} and Ivan Visconti"
         vol:            "5229"
         addr:
             @0:         "Amalfi, Italy"
@@ -12878,7 +12878,7 @@ scn:
         name:
             @0:         "SCN 10: 7th " # scnname
             @2:         "SCN 10" # scnname
-        ed:             "Juan A. Garay and Roberto De Prisco"
+        ed:             "Juan A. Garay and Roberto {De Prisco}"
         vol:            "6280"
         addr:
             @0:         "Amalfi, Italy"
@@ -12892,7 +12892,7 @@ scn:
         name:
             @0:         "SCN 12: 8th " # scnname
             @2:         "SCN 12" # scnname
-        ed:             "Ivan Visconti and Roberto De Prisco"
+        ed:             "Ivan Visconti and Roberto {De Prisco}"
         vol:            "7485"
         addr:
             @0:         "Amalfi, Italy"
@@ -12906,7 +12906,7 @@ scn:
         name:
             @0:         "SCN 14: 9th " # scnname
             @2:         "SCN 14" # scnname
-        ed:             "Michel Abdalla and Roberto De Prisco"
+        ed:             "Michel Abdalla and Roberto {De Prisco}"
         vol:            "8642"
         addr:
             @0:         "Amalfi, Italy"

--- a/config.py
+++ b/config.py
@@ -147,7 +147,7 @@ add_conf("CHES", "Workshop on Cryptographic Hardware and Embedded Systems")
 add_conf("COSADE", "International Workshop on Constructive Side-Channel Analysis and Secure Design")
 add_conf("CQRE", "International Exhibition and Congress on Network Security", name="CQRE")
 # Some CSF ('07-'16) are labeled csfw/csf, remaining csfw/csfw
-# 
+#
 add_conf("CSF", "IEEE Computer Security Foundations Symposium", name="CSF", url="https://dblp.uni-trier.de/db/conf/csfw/csf${url_year}.html")
 add_conf("C", "International Cryptology Conference", name="CRYPTO")
 add_conf("RSA", "RSA Conference, Cryptographers' Track", name="CT-RSA", crossref="rsa",
@@ -237,6 +237,7 @@ add_journal("DCC", 1933, "dcc", "Designs, Codes and Cryptography",
 add_journal("CiC", 2024, "cic", "IACR Communications in Cryptology",
             url="https://dblp.uni-trier.de/db/journals/cic/cic${volume}.html", publisher="iacr_pub",)
 
+
 def get_conf_name(confkey):
     if confkey in confs:
         return confs[confkey]["name"]
@@ -244,7 +245,7 @@ def get_conf_name(confkey):
         return confkey.upper()
 
 
-# Missing years for conferences (used by lib.confs_years
+# Missing years for conferences (used by lib.confs_years)
 
 confs_missing_years = {
     "AC": {1993, 1995, 1997},

--- a/crypto_misc.bib
+++ b/crypto_misc.bib
@@ -431,7 +431,7 @@
 }
 
 @techreport{NISTPQC-R3:SABER20,
-  author       = {Jan-Pieter D'Anvers and Angshuman Karmakar and Sujoy Sinha Roy and Frederik Vercauteren and Jose Maria Bermudo Mera and Michiel Van Beirendonck and Andrea Basso},
+  author       = {Jan-Pieter D'Anvers and Angshuman Karmakar and Sujoy Sinha Roy and Frederik Vercauteren and Jose Maria Bermudo Mera and Michiel {Van Beirendonck} and Andrea Basso},
   title        = {{SABER}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,

--- a/crypto_misc.bib
+++ b/crypto_misc.bib
@@ -3034,7 +3034,7 @@ year =           1997,
 }
 
 @InCollection{MraPagVer12,
-  author =       "Nadia El Mrabet and 
+  author =       "Nadia {El Mrabet} and 
                   Dan Page and 
                   Frederik Vercauteren",
   title =        "Fault Attacks on Pairing-Based Cryptography",

--- a/crypto_misc.bib
+++ b/crypto_misc.bib
@@ -1323,7 +1323,7 @@
 
 @InProceedings{ForKal00,
   author =       "Warwick Ford and
-                  Burton S. {Kaliski Jr.}",
+                  Kaliski, Jr., Burton S.",
   title =        "Server-Assisted Generation of a Strong Secret from a Password",
   pages =        "176--180",
   booktitle =    "9th IEEE International Workshops on Enabling Technologies: Infrastructure for Collaborative Enterprises (WETICE 2000)",
@@ -3262,7 +3262,7 @@ year =           1997,
 @InCollection{SLLLB10,
   author =       "Ionica Smeets and 
                   Arjen K. Lenstra and 
-                  Hendrik Lenstra and 
+                  Lenstra, Jr., Hendrik W. and 
                   L{\'a}szl{\'o} Lov{\'a}sz and 
                   Peter van Emde Boas",
   title =        "The History of the {LLL}-Algorithm",
@@ -3538,7 +3538,7 @@ year =           1997,
   key =          "RFC",
   author =       "Neil Haller and
                   Craig Metz and
-                  Philip J. {Nesser II} and
+                  Nesser, II, Philip J. and
                   Mike Straw",
   title =        "{RFC} 2289: A One-Time Password System",
   organization = "Internet Activities Board",

--- a/crypto_misc.bib
+++ b/crypto_misc.bib
@@ -86,7 +86,7 @@
 }
 
 @techreport{NISTPQC-ADD-R1:HAWK23,
-  author       = {Joppe W. Bos and Olivier Bronchain and L\'{e}o Ducas and Serge Fehr and {Yu-Hsuan} Huang and Thomas Pornin and Eamonn W. Postlethwaite and Thomas Prest and Ludo N. Pulles and Wessel {van Woerden}},
+  author       = {Joppe W. Bos and Olivier Bronchain and L\'{e}o Ducas and Serge Fehr and {Yu-Hsuan} Huang and Thomas Pornin and Eamonn W. Postlethwaite and Thomas Prest and Ludo N. Pulles and Wessel van Woerden},
   title        = {{HAWK}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2023,
@@ -491,7 +491,7 @@
 @techreport{NISTPQC-R3:NTRUPrime20,
   author       = {Daniel J. Bernstein and Billy Bob Brumley and Ming-Shing Chen
  and Chitchanok Chuengsatiansup and Tanja Lange and Adrian Marotzke
- and Bo-Yuan Peng and Nicola Tuveri and Christine {van Vredendaal} and Bo-Yin Yang},
+ and Bo-Yuan Peng and Nicola Tuveri and Christine van Vredendaal and Bo-Yin Yang},
   title        = {{NTRU Prime}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,
@@ -608,7 +608,7 @@
 }
 
 @techreport{NISTPQC-R2:NTRUPrime19,
-  author       = {Daniel J. Bernstein and Chitchanok Chuengsatiansup and Tanja Lange and Christine {van Vredendaal}},
+  author       = {Daniel J. Bernstein and Chitchanok Chuengsatiansup and Tanja Lange and Christine van Vredendaal},
   title        = {{NTRU Prime}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2019,
@@ -1102,7 +1102,7 @@
 }
 
 @techreport{NISTPQC-R1:NTRUPrime17,
-  author       = {Daniel J. Bernstein and Chitchanok Chuengsatiansup and Tanja Lange and Christine {van Vredendaal}},
+  author       = {Daniel J. Bernstein and Chitchanok Chuengsatiansup and Tanja Lange and Christine van Vredendaal},
   title        = {{NTRU Prime}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2017,
@@ -2104,7 +2104,7 @@
 
 @Article{StiVan98,
   author =       "Douglas R. Stinson and
-                  Tran {van Trung}",
+                  Tran van Trung",
   title =        "Some New Results on Key Distribution Patterns and Broadcast Encryption",
   journal =      "Designs, Codes and Cryptography",
   year =         1998,
@@ -2125,7 +2125,7 @@ year =           1997,
 
 @Article{DifVanWie92,
   author =       "Whitfield Diffie and
-                  Paul C. {van Oorschot} and
+                  Paul C. van Oorschot and
                   Michael J. Wiener",
   title =        "Authentication and Authenticated Key Exchanges",
   pages =        "107--125",
@@ -3781,7 +3781,7 @@ year =           1997,
 
 @Book{MenVanVan97,
   author =       "Alfred J. Menezes and
-                  Paul C. {van Oorschot} and
+                  Paul C. van Oorschot and
                   Scott A. Vanstone",
   title =        "Handbook of Applied Cryptography",
   publisher =    "CRC Press",
@@ -3856,7 +3856,7 @@ year =           1997,
 
 @Book{MenVanVan96,
   author =       "Alfred J. Menezes and
-                  Paul C. {van Oorschot} and
+                  Paul C. van Oorschot and
                   Scott A. Vanstone",
   title =        "Handbook of Applied Cryptography",
   publisher =    "CRC Press",


### PR DESCRIPTION
This pull request contains multiple changes:

- *von prefix*: A prefix for the last name (`van / van de / de la / von / d'` but not `Van / Van de / O'`) was sometimes incorrectly seen as part of the last name, which caused the abbreviation (if using e.g. alpha.bst) to be incorrect like `[van ] / [de ]`. As explained in https://github.com/cryptobib/db/issues/107#issuecomment-1843214981, by using a 'good' .bst-file in your LaTeX file that sorts on last name not including prefix, alphabetic sorting happens as expected. Even with alpha.bst you have abbreviations like `[DvW21]` already which is as expected.
- Example, I changed "`Lo{\"i}c {van Oldeneel tot Oldenzeel`" to "`Lo{\"i}c van {Oldeneel tot Oldenzeel}`" because without the {}-braces, Bibtex thinks "van Oldeneel tot" is the von-prefix (according to the [TameTheBeast manual](https://ctan.org/pkg/tamethebeast)) which it isn't.
- Lineage was sometimes taken part of the last name when it's not Jr./Sr. but a number, e.g. `William E. Skeith III` used to be wrong. I forced an encoding of `von Last, Jr., First` when a lineage appears, to make sure it's parsed correctly.
- Many Belgian names did not include the last name, e.g. I changed "`Gilles Van Assche`" to "`Gilles {Van Assche}`".
- Many Spanish/Italian/Portuguese names had a similar issue, e.g. I changed "`Alfredo De Santis`" to "`Alfredo {De Santis}`" (similar for "`Ivan {De Oliveira Nunes}`").
- Changed Maroccan names, e.g. I changed "`Youssef El Housni`" to "`Youssef {El Housni}`".
- Many ePrint entries have no spaces, where there should be spaces, e.g. in [EPRINT:Lu23] I changed "`Frank Y.C. Lu`" to "`Frank Y. C. Lu`".
- Various name fixes, removing unparsed special characters that appear as "?", e.g. [EPRINT:GaiKiaRus2] has author "Peter Gaži".

I used a script to more or less automate these changes. I can make a PR for these scripts in `db_tools` and the `lib` (for changes to Person class) repositories if wanted. I believe that the import script `db_import/import.py` needs to be revised to do these names good in the future.

*Note*: this does not update the ePrint labels, also because there was an open pull request #252 . Once this Pull Request is done, I have a fix for all the >6 letter labels _and_ outdated labels, which is here: https://github.com/ludopulles/crypto_db/tree/fix-252
I'll create a PR for that, once/if this is merged.

Closes: #107

