### PR TITLE
Fix #252

### DIFF
--- a/crypto_misc.bib
+++ b/crypto_misc.bib
@@ -3231,7 +3231,7 @@ year =           1997,
 }
 
 @InCollection{DGLM10,
-  author =       "Lo{\"\i}c Duflot and 
+  author =       "Lo{\"i}c Duflot and 
                   Olivier Grumelard and 
                   Olivier Levillain and 
                   Benjamin Morin",
@@ -3398,7 +3398,7 @@ year =           1997,
 
 @InCollection{BLMQ10a,
   author =       "Paulo S. L. M. Barreto and 
-                  Beno{\^\i}t Libert and 
+                  Beno{\^i}t Libert and 
                   Noel McCullagh and 
                   Jean-Jacques Quisquater",
   title =        "Signcryption Schemes Based on the Diffie-Hellman Problem",
@@ -3408,7 +3408,7 @@ year =           1997,
 
 @InCollection{BLMQ10b,
   author =       "Paulo S. L. M. Barreto and 
-                  Beno{\^\i}t Libert and 
+                  Beno{\^i}t Libert and 
                   Noel McCullagh and 
                   Jean-Jacques Quisquater",
   title =        "Signcryption Schemes Based on Bilinear Maps",


### PR DESCRIPTION
Fixes more than what is discussed in pull request https://github.com/cryptobib/db/pull/252:
- If a von-prefix occurs, add all the first letters to the shortened name, e.g.
	"Jeroen van de Graaf", Crypto 2010 => C:vdGraaf10
- Some names have been updated, but the labels were still outdated, e.g.
	[EC:Burmester90a] => [EC:BurDes90]
- Delicate care is taken into account that some keys were colliding so a "dis"-disambiguation is added, e.g.
	[EPRINT:UnrDom12] & [EPRINT:Unruh12] => [EPRINT:Unruh12a] & [EPRINT:Unruh12b]
- Various name fixes related to accents (and Tommaso d'Orsi).

Closes: #252
