### PR TITLE
Add NIST PQC Round 2 Additional Signatures

### DIFF
--- a/crypto_misc.bib
+++ b/crypto_misc.bib
@@ -1,4 +1,126 @@
 %------------------------------------------------------------------
+%                      NIST PQC STANDARDIZATION of Additional Digital Signature ROUND 2
+%------------------------------------------------------------------
+
+% ============= Code-based Signatures
+@techreport{NISTPQC-ADD-R2:CROSS24,
+  author       = {Marco Baldi and Alessandro Barenghi and Sebastian Bitzer and Patrick Karl and Felice Manganiello and Alessio Pavoni and Gerardo Pelosi and Paolo Santini and Jonas Schupp and Freeman Slaughter and Antonia {Wachter-Zeh} and Violetta Weger},
+  title        = {{CROSS} --- {Codes and Restricted Objects Signature Scheme}},
+  institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
+  year         = 2024,
+  note         = {available at \url{https://csrc.nist.gov/Projects/pqc-dig-sig/round-2-additional-signatures}},
+}
+
+@techreport{NISTPQC-ADD-R2:LESS24,
+  author       = {Marco Baldi and Alessandro Barenghi and Luke Beckwith and {Jean-Fran\c{c}ois} Biasse and Andre Esser and Kris Gaj and Kamyar Mohajerani and Gerardo Pelosi and Edoardo Persichetti and {Markku-Juhani} O. Saarinen and Paolo Santini and Robert Wallace},
+  title        = {{LESS} --- {Linear Equivalence Signature Scheme}},
+  institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
+  year         = 2024,
+  note         = {available at \url{https://csrc.nist.gov/Projects/pqc-dig-sig/round-2-additional-signatures}},
+}
+
+% ============= Isogeny Signatures
+@techreport{NISTPQC-ADD-R2:SQIsign24,
+  author       = {Jorge {Chavez-Saab} and Maria {Corte-Real} Santos and Luca {De Feo} and Jonathan Komada Eriksen and Basil Hess and David Kohel and Antonin Leroux and Patrick Longa and Michael Meyer and Lorenz Panny and Sikhar Patranabis and Christophe Petit and Francisco {Rodr\'{i}guez Henr\'{i}quez} and Sina Schaeffler and Benjamin Wesolowski},
+  title        = {{SQIsign}},
+  institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
+  year         = 2024,
+  note         = {available at \url{https://csrc.nist.gov/Projects/pqc-dig-sig/round-2-additional-signatures}},
+}
+
+% ============= Lattice-based Signatures
+@techreport{NISTPQC-ADD-R2:HAWK24,
+  author       = {Joppe W. Bos and Olivier Bronchain and L\'{e}o Ducas and Serge Fehr and {Yu-Hsuan} Huang and Thomas Pornin and Eamonn W. Postlethwaite and Thomas Prest and Ludo N. Pulles and Wessel {van Woerden}},
+  title        = {{HAWK}},
+  institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
+  year         = 2024,
+  note         = {available at \url{https://csrc.nist.gov/Projects/pqc-dig-sig/round-2-additional-signatures}},
+}
+
+% ============= MPC-in-the-Head Signatures
+@techreport{NISTPQC-ADD-R2:Mirath24,
+  author       = {Nicolas Aragon and Magali Bardet and Lo\"{i}c Bidoux and {Jes\'{u}s-Javier} {Chi-Dom\'{i}nguez} and Victor Dyseryn and Thibauld Feneuil and Philippe Gaborit and Romaric Neveu and Matthieu Rivain and {Jean-Pierre} Tillich and Gora Adj and Luis {Rivera-Zamarripa} and Javier Verbel and Emanuele Bellini and Stefano Barbero and Andre Esser and Carlo Sanna and Floyd Zweydinger},
+  title        = {{Mirath (merger of {MIRA}/{MiRitH})}},
+  institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
+  year         = 2024,
+  note         = {available at \url{https://csrc.nist.gov/Projects/pqc-dig-sig/round-2-additional-signatures}},
+}
+
+@techreport{NISTPQC-ADD-R2:MQOM24,
+  author       = {Thibauld Feneuil and Matthieu Rivain},
+  title        = {{MQOM} --- {MQ on my Mind}},
+  institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
+  year         = 2024,
+  note         = {available at \url{https://csrc.nist.gov/Projects/pqc-dig-sig/round-2-additional-signatures}},
+}
+
+@techreport{NISTPQC-ADD-R2:PERK24,
+  author       = {Najwa Aaraj and Slim Bettaieb and Lo\"{i}c Bidoux and Alessandro Budroni and Victor Dyseryn and Andre Esser and Philippe Gaborit and Mukul Kulkarni and Victor Mateu and Marco Palumbi and Lucas Perin and {Jean-Pierre} Tillich},
+  title        = {{PERK}},
+  institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
+  year         = 2024,
+  note         = {available at \url{https://csrc.nist.gov/Projects/pqc-dig-sig/round-2-additional-signatures}},
+}
+
+@techreport{NISTPQC-ADD-R2:RYDE24,
+  author       = {Nicolas Aragon and Magali Bardet and Lo\"{i}c Bidoux and {Jes\'{u}s-Javier} {Chi-Dom\'{i}nguez} and Victor Dyseryn and Thibauld Feneuil and Philippe Gaborit and Antoine Joux and Matthieu Rivain and {Jean-Pierre} Tillich and Adrien Vin\c{c}otte},
+  title        = {{RYDE}},
+  institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
+  year         = 2024,
+  note         = {available at \url{https://csrc.nist.gov/Projects/pqc-dig-sig/round-2-additional-signatures}},
+}
+
+@techreport{NISTPQC-ADD-R2:SDitH24,
+  author       = {Carlos {Aguilar-Melchor} and Thibauld Feneuil and Nicolas Gama and Shay Gueron and James Howe and David Joseph and Antoine Joux and Edoardo Persichetti and Tovohery H. Randrianarisoa and Matthieu Rivain and Dongze Yue},
+  title        = {{SDitH} --- {Syndrome Decoding in the Head}},
+  institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
+  year         = 2024,
+  note         = {available at \url{https://csrc.nist.gov/Projects/pqc-dig-sig/round-2-additional-signatures}},
+}
+
+% ============= Multivariate Signatures
+@techreport{NISTPQC-ADD-R2:MAYO24,
+  author       = {Ward Beullens and Fabio Campos and Sof\'{i}a Celi and Basil Hess and Matthias J. Kannwischer},
+  title        = {{MAYO}},
+  institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
+  year         = 2024,
+  note         = {available at \url{https://csrc.nist.gov/Projects/pqc-dig-sig/round-2-additional-signatures}},
+}
+
+@techreport{NISTPQC-ADD-R2:QR-UOV24,
+  author       = {Hiroki Furue and Yasuhiko Ikematsu and Fumitaka Hoshino and Tsuyoshi Takagi and Kan Yasuda and Toshiyuki Miyazawa and Tsunekazu Saito and Akira Nagai},
+  title        = {{QR-UOV}},
+  institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
+  year         = 2024,
+  note         = {available at \url{https://csrc.nist.gov/Projects/pqc-dig-sig/round-2-additional-signatures}},
+}
+
+@techreport{NISTPQC-ADD-R2:SNOVA24,
+  author       = {{Lih-Chung} Wang and {Chun-Yen} Chou and Jintai Ding and {Yen-Liang} Kuan and {Ming-Siou} Li and {Bo-Shu} Tseng and {Po-En} Tseng and {Chia-Chun} Wang},
+  title        = {{SNOVA}},
+  institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
+  year         = 2024,
+  note         = {available at \url{https://csrc.nist.gov/Projects/pqc-dig-sig/round-2-additional-signatures}},
+}
+
+@techreport{NISTPQC-ADD-R2:UOV24,
+  author       = {Ward Beullens and {Ming-Shing} Chen and Jintai Ding and Boru Gong and Matthias J. Kannwischer and Jacques Patarin and {Bo-Yuan} Peng and Dieter Schmidt and {Cheng-Jhih} Shih and Chengdong Tao and {Bo-Yin} Yang},
+  title        = {{UOV} --- {Unbalanced Oil and Vinegar}},
+  institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
+  year         = 2024,
+  note         = {available at \url{https://csrc.nist.gov/Projects/pqc-dig-sig/round-2-additional-signatures}},
+}
+
+% ============= Symmetric-based Signatures
+@techreport{NISTPQC-ADD-R2:FAEST24,
+  author       = {Carsten Baum and Lennart Braun and Cyprien Delpech {de Saint Guilhem} and Michael Kloo{\ss} and Christian Majenz and Shibam Mukherjee and Emmanuela Orsini and Sebastian Ramacher and Christian Rechberger and Lawrence Roy and Peter Scholl},
+  title        = {{FAEST}},
+  institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
+  year         = 2024,
+  note         = {available at \url{https://csrc.nist.gov/Projects/pqc-dig-sig/round-2-additional-signatures}},
+}
+
+%------------------------------------------------------------------
 %                      NIST PQC STANDARDIZATION of Additional Digital Signature ROUND 1
 %------------------------------------------------------------------
 


### PR DESCRIPTION
Added round-2 candidates in https://csrc.nist.gov/Projects/pqc-dig-sig/round-2-additional-signatures