### PR TITLE
Fix last name in FAEST reference

### DIFF
--- a/crypto_misc.bib
+++ b/crypto_misc.bib
@@ -113,7 +113,7 @@
 
 % ============= Symmetric-based Signatures
 @techreport{NISTPQC-ADD-R2:FAEST24,
-  author       = {Carsten Baum and Lennart Braun and Cyprien Delpech {de Saint Guilhem} and Michael Kloo{\ss} and Christian Majenz and Shibam Mukherjee and Emmanuela Orsini and Sebastian Ramacher and Christian Rechberger and Lawrence Roy and Peter Scholl},
+  author       = {Carsten Baum and Lennart Braun and Cyprien {Delpech de Saint Guilhem} and Michael Kloo{\ss} and Christian Majenz and Shibam Mukherjee and Emmanuela Orsini and Sebastian Ramacher and Christian Rechberger and Lawrence Roy and Peter Scholl},
   title        = {{FAEST}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2024,
@@ -126,7 +126,7 @@
 
 % ============= Code-based Signatures
 @techreport{NISTPQC-ADD-R1:CROSS23,
-  author       = {Marco Baldi and Alessandro Barenghi and Sebastian Bitzer and Patrick Karl and Felice Manganiello and Alessio Pavoni and Gerardo Pelosi and Paolo Santini and Jonas Schupp and Freeman Slaughter and Antonia {Wachter-Zeh} and Violetta Weger}, 
+  author       = {Marco Baldi and Alessandro Barenghi and Sebastian Bitzer and Patrick Karl and Felice Manganiello and Alessio Pavoni and Gerardo Pelosi and Paolo Santini and Jonas Schupp and Freeman Slaughter and Antonia {Wachter-Zeh} and Violetta Weger},
   title        = {{CROSS} --- {Codes and Restricted Objects Signature Scheme}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2023,
@@ -142,7 +142,7 @@
 }
 
 @techreport{NISTPQC-ADD-R1:FuLeeca23,
-  author       = {Stefan Ritterhoff and Sebastian Bitzer and Patrick Karl and Georg Maringer and Thomas Schamberger and Jonas Schupp and Georg Sigl and Antonia {Wachter-Zeh} and Violetta Weger}, 
+  author       = {Stefan Ritterhoff and Sebastian Bitzer and Patrick Karl and Georg Maringer and Thomas Schamberger and Jonas Schupp and Georg Sigl and Antonia {Wachter-Zeh} and Violetta Weger},
   title        = {{FuLeeca}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2023,
@@ -166,7 +166,7 @@
 }
 
 @techreport{NISTPQC-ADD-R1:Wave23,
-  author       = {Gustavo Banegas and K\'{e}vin Carrier and Andr\'{e} Chailloux and Alain Couvreur and Thomas {Debris-Alazard} and Philippe Gaborit and Pierre Karpman and Johanna Loyer and Ruben Niederhagen and Nicolas Sendrier and Benjamin Smith and {Jean-Pierre} Tillich}, 
+  author       = {Gustavo Banegas and K\'{e}vin Carrier and Andr\'{e} Chailloux and Alain Couvreur and Thomas {Debris-Alazard} and Philippe Gaborit and Pierre Karpman and Johanna Loyer and Ruben Niederhagen and Nicolas Sendrier and Benjamin Smith and {Jean-Pierre} Tillich},
   title        = {{Wave}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2023,
@@ -175,7 +175,7 @@
 
 % ============= Isogeny Signatures
 @techreport{NISTPQC-ADD-R1:SQIsign23,
-  author       = {Jorge {Chavez-Saab} and Maria {Corte-Real} Santos and Luca {De Feo} and Jonathan Komada Eriksen and Basil Hess and David Kohel and Antonin Leroux and Patrick Longa and Michael Meyer and Lorenz Panny and Sikhar Patranabis and Christophe Petit and Francisco {Rodr\'{i}guez Henr\'{i}quez} and Sina Schaeffler and Benjamin Wesolowski}, 
+  author       = {Jorge {Chavez-Saab} and Maria {Corte-Real} Santos and Luca {De Feo} and Jonathan Komada Eriksen and Basil Hess and David Kohel and Antonin Leroux and Patrick Longa and Michael Meyer and Lorenz Panny and Sikhar Patranabis and Christophe Petit and Francisco {Rodr\'{i}guez Henr\'{i}quez} and Sina Schaeffler and Benjamin Wesolowski},
   title        = {{SQIsign}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2023,
@@ -184,7 +184,7 @@
 
 % ============= Lattice-based Signatures
 @techreport{NISTPQC-ADD-R1:EagleSign23,
-  author       = {Djiby Sow and Abiodoun Clement Hounkpevi and Sidoine Djimnaibeye and Michel Seck}, 
+  author       = {Djiby Sow and Abiodoun Clement Hounkpevi and Sidoine Djimnaibeye and Michel Seck},
   title        = {{EagleSign}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2023,
@@ -241,7 +241,7 @@
 
 % ============= MPC-in-the-Head Signatures
 @techreport{NISTPQC-ADD-R1:Biscuit23,
-  author       = {Luk Bettale and Delaram Kahrobaei and Ludovic Perret and Javier Verbel}, 
+  author       = {Luk Bettale and Delaram Kahrobaei and Ludovic Perret and Javier Verbel},
   title        = {{Biscuit}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2023,
@@ -395,7 +395,7 @@
 }
 
 @techreport{NISTPQC-ADD-R1:FAEST23,
-  author       = {Carsten Baum and Lennart Braun and Cyprien Delpech {de Saint Guilhem} and Michael Kloo{\ss} and Christian Majenz and Shibam Mukherjee and Emmanuela Orsini and Sebastian Ramacher and Christian Rechberger and Lawrence Roy and Peter Scholl},
+  author       = {Carsten Baum and Lennart Braun and Cyprien {Delpech de Saint Guilhem} and Michael Kloo{\ss} and Christian Majenz and Shibam Mukherjee and Emmanuela Orsini and Sebastian Ramacher and Christian Rechberger and Lawrence Roy and Peter Scholl},
   title        = {{FAEST}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2023,
@@ -499,7 +499,7 @@
 }
 
 @techreport{NISTPQC-R4:ClassicMcEliece22,
-  author       = {Martin R. Albrecht and Daniel J. Bernstein and Tung Chou and Carlos Cid and Jan Gilcher and Tanja Lange and Varun Maram and Ingo von Maurich and Rafael Misoczki and Ruben Niederhagen and Kenneth G. Paterson and Edoardo Persichetti and Christiane Peters and Peter Schwabe and Nicolas Sendrier and Jakub Szefer and Cen Jung Tjhai and Martin Tomlinson and Wen Wang}, 
+  author       = {Martin R. Albrecht and Daniel J. Bernstein and Tung Chou and Carlos Cid and Jan Gilcher and Tanja Lange and Varun Maram and Ingo von Maurich and Rafael Misoczki and Ruben Niederhagen and Kenneth G. Paterson and Edoardo Persichetti and Christiane Peters and Peter Schwabe and Nicolas Sendrier and Jakub Szefer and Cen Jung Tjhai and Martin Tomlinson and Wen Wang},
   title        = {{Classic McEliece}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2022,
@@ -507,7 +507,7 @@
 }
 
 @techreport{NISTPQC-R4:HQC22,
-  author       = {Carlos {Aguilar-Melchor} and Nicolas Aragon and Slim Bettaieb and Lo{\"i}c Bidoux and Olivier Blazy and Jean-Christophe Deneuville 
+  author       = {Carlos {Aguilar-Melchor} and Nicolas Aragon and Slim Bettaieb and Lo{\"i}c Bidoux and Olivier Blazy and Jean-Christophe Deneuville
   and Philippe Gaborit and Edoardo Persichetti and Gilles Z{\'e}mor and Jurjen Bos and Arnaud Dion and Jerome Lacan and Jean-Marc Robert and Pascal Veron},
   title        = {{HQC}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
@@ -529,7 +529,7 @@
 
 % ============= Finalists: PKE/KEM
 @techreport{NISTPQC-R3:ClassicMcEliece20,
-  author       = {Martin R. Albrecht and Daniel J. Bernstein and Tung Chou and Carlos Cid and Jan Gilcher and Tanja Lange and Varun Maram and Ingo von Maurich and Rafael Misoczki and Ruben Niederhagen and Kenneth G. Paterson and Edoardo Persichetti and Christiane Peters and Peter Schwabe and Nicolas Sendrier and Jakub Szefer and Cen Jung Tjhai and Martin Tomlinson and Wen Wang}, 
+  author       = {Martin R. Albrecht and Daniel J. Bernstein and Tung Chou and Carlos Cid and Jan Gilcher and Tanja Lange and Varun Maram and Ingo von Maurich and Rafael Misoczki and Ruben Niederhagen and Kenneth G. Paterson and Edoardo Persichetti and Christiane Peters and Peter Schwabe and Nicolas Sendrier and Jakub Szefer and Cen Jung Tjhai and Martin Tomlinson and Wen Wang},
   title        = {{Classic McEliece}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,
@@ -545,7 +545,7 @@
 }
 
 @techreport{NISTPQC-R3:NTRU20,
-  author       = {Cong Chen and Oussama Danba and Jeffrey Hoffstein and Andreas Hulsing and Joost Rijneveld and John M. Schanck and Peter Schwabe and William Whyte and Zhenfei Zhang and Tsunekazu Saito and Takashi Yamakawa and Keita Xagawa}, 
+  author       = {Cong Chen and Oussama Danba and Jeffrey Hoffstein and Andreas Hulsing and Joost Rijneveld and John M. Schanck and Peter Schwabe and William Whyte and Zhenfei Zhang and Tsunekazu Saito and Takashi Yamakawa and Keita Xagawa},
   title        = {{NTRU}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2020,
@@ -3057,7 +3057,7 @@ year =           1997,
 %------------------------------------------------------------------
 
 @InCollection{OswSta12,
-  author =       "Elisabeth Oswald and 
+  author =       "Elisabeth Oswald and
                   Fran{\c c}ois-Xavier Standaert",
   title =        "Side-Channel Analysis and Its Relevance to Fault Attacks",
   pages =        "3--15",
@@ -3086,7 +3086,7 @@ year =           1997,
 }
 
 @InCollection{SchMed12,
-  author =       "J{\"o}rn-Marc Schmidt and 
+  author =       "J{\"o}rn-Marc Schmidt and
                   Marcel Medwed",
   title =        "Countermeasures for Symmetric Key Ciphers",
   pages =        "73--87",
@@ -3094,9 +3094,9 @@ year =           1997,
 }
 
 @InCollection{BDFR12,
-  author =       "Kaouthar Bousselam and 
-                  Giorgio {Di Natale} and 
-                  Marie-Lise Flottes and 
+  author =       "Kaouthar Bousselam and
+                  Giorgio {Di Natale} and
+                  Marie-Lise Flottes and
                   Bruno Rouzeyre",
   title =        "On Countermeasures Against Fault Attacks on the Advanced Encryption Standard",
   pages =        "89--108",
@@ -3104,8 +3104,8 @@ year =           1997,
 }
 
 @InCollection{BerCanGou12,
-  author =       "Alexandre Berzati and 
-                  C{\'e}cile {Canovas-Dumas} and 
+  author =       "Alexandre Berzati and
+                  C{\'e}cile {Canovas-Dumas} and
                   Louis Goubin",
   title =        "A Survey of Differential Fault Analysis Against Classical {RSA} Implementations",
   pages =        "111--124",
@@ -3113,7 +3113,7 @@ year =           1997,
 }
 
 @InCollection{KimQui12,
-  author =       "Chong Hee Kim and 
+  author =       "Chong Hee Kim and
                   Jean-Jacques Quisquater",
   title =        "Fault Attacks Against {RSA}-{CRT} Implementation",
   pages =        "125--136",
@@ -3121,8 +3121,8 @@ year =           1997,
 }
 
 @InCollection{AlkDomHas12,
-  author =       "Abdulaziz Alkhoraidly and 
-                  Agustin Dominguez-Oviedo and 
+  author =       "Abdulaziz Alkhoraidly and
+                  Agustin Dominguez-Oviedo and
                   M. Anwar Hasan",
   title =        "Fault Attacks on Elliptic Curve Cryptosystems",
   pages =        "137--155",
@@ -3130,7 +3130,7 @@ year =           1997,
 }
 
 @InCollection{HarRey12,
-  author =       "Arash Hariri and 
+  author =       "Arash Hariri and
                   Arash {Reyhani-Masoleh}",
   title =        "On Countermeasures Against Fault Attacks on Elliptic Curve Cryptography Using Fault Detection",
   pages =        "157--169",
@@ -3138,9 +3138,9 @@ year =           1997,
 }
 
 @InCollection{AWKS12,
-  author =       "Kahraman D. Akdemir and 
-                  Zhen Wang and 
-                  Mark G. Karpovsky and 
+  author =       "Kahraman D. Akdemir and
+                  Zhen Wang and
+                  Mark G. Karpovsky and
                   Berk Sunar",
   title =        "Design of Cryptographic Devices Resilient to Fault Injection Attacks Using Nonlinear Robust Codes",
   pages =        "171--199",
@@ -3148,7 +3148,7 @@ year =           1997,
 }
 
 @InCollection{NguTib12,
-  author =       "Phong Q. Nguyen and 
+  author =       "Phong Q. Nguyen and
                   Mehdi Tibouchi",
   title =        "Lattice-Based Fault Attacks on Signatures",
   pages =        "201--220",
@@ -3156,8 +3156,8 @@ year =           1997,
 }
 
 @InCollection{MraPagVer12,
-  author =       "Nadia {El Mrabet} and 
-                  Dan Page and 
+  author =       "Nadia {El Mrabet} and
+                  Dan Page and
                   Frederik Vercauteren",
   title =        "Fault Attacks on Pairing-Based Cryptography",
   pages =        "221--236",
@@ -3165,7 +3165,7 @@ year =           1997,
 }
 
 @InCollection{BarTri12,
-  author =       "Alessandro Barenghi and 
+  author =       "Alessandro Barenghi and
                   Elena Trichina",
   title =        "Fault Attacks on Stream Ciphers",
   pages =        "239--255",
@@ -3173,9 +3173,9 @@ year =           1997,
 }
 
 @InCollection{RBIK12,
-  author =       "Francesco Regazzoni and 
-                  Luca Breveglieri and 
-                  Paolo Ienne and 
+  author =       "Francesco Regazzoni and
+                  Luca Breveglieri and
+                  Paolo Ienne and
                   Israel Koren",
   title =        "Interaction Between Fault Attack Countermeasures and the Resistance Against Power Analysis Attacks",
   pages =        "257--272",
@@ -3183,10 +3183,10 @@ year =           1997,
 }
 
 @InCollection{BBBPP12,
-  author =       "Alessandro Barenghi and 
-                  Guido Marco Bertoni and 
-                  Luca Breveglieri and 
-                  Mauro Pellicioli and 
+  author =       "Alessandro Barenghi and
+                  Guido Marco Bertoni and
+                  Luca Breveglieri and
+                  Mauro Pellicioli and
                   Gerardo Pelosi",
   title =        "Injection Technologies for Fault Attacks on Microprocessors",
   pages =        "275--293",
@@ -3194,7 +3194,7 @@ year =           1997,
 }
 
 @InCollection{GuiDan12,
-  author =       "Sylvain Guilley and 
+  author =       "Sylvain Guilley and
                   Jean-Luc Danger",
   title =        "Global Faults on Cryptographic Circuits",
   pages =        "295--311",
@@ -3202,11 +3202,11 @@ year =           1997,
 }
 
 @InCollection{TFGLSO12,
-  author =       "Junko Takahashi and 
-                  Toshinori Fukunaga and 
-                  Shigeto Gomisawa and 
-                  Yang Li and 
-                  Kazuo Sakiyama and 
+  author =       "Junko Takahashi and
+                  Toshinori Fukunaga and
+                  Shigeto Gomisawa and
+                  Yang Li and
+                  Kazuo Sakiyama and
                   Kazuo Ohta",
   title =        "Fault Injection and Key Retrieval Experiments on an Evaluation Board",
   pages =        "313--331",
@@ -3214,7 +3214,7 @@ year =           1997,
 }
 
 @InCollection{MaeVer10,
-  author =       "Roel Maes and 
+  author =       "Roel Maes and
                   Ingrid Verbauwhede",
   title =        "Physically Unclonable Functions: {A} Study on the State of the Art and Future Research Directions",
   pages =        "3--37",
@@ -3222,8 +3222,8 @@ year =           1997,
 }
 
 @InCollection{HanSchTuy10,
-  author =       "Helena Handschuh and 
-                  Geert Jan Schrijen and 
+  author =       "Helena Handschuh and
+                  Geert Jan Schrijen and
                   Pim Tuyls",
   title =        "Hardware Intrinsic Security from Physically Unclonable Functions",
   pages =        "39--53",
@@ -3231,11 +3231,11 @@ year =           1997,
 }
 
 @InCollection{KMNSVZ10,
-  author =       "Inyoung Kim and 
-                  Abhranil Maiti and 
-                  Leyla Nazhandali and 
-                  Patrick Schaumont and 
-                  Vignesh Vivekraja and 
+  author =       "Inyoung Kim and
+                  Abhranil Maiti and
+                  Leyla Nazhandali and
+                  Patrick Schaumont and
+                  Vignesh Vivekraja and
                   Huaiye Zhang",
   title =        "From Statistics to Circuits: Foundations for Future Physical Unclonable Functions",
   pages =        "55--78",
@@ -3243,8 +3243,8 @@ year =           1997,
 }
 
 @InCollection{RuhBusKat10,
-  author =       "Ulrich R{\"u}hrmair and 
-                  Heike Busch and 
+  author =       "Ulrich R{\"u}hrmair and
+                  Heike Busch and
                   Stefan Katzenbeisser",
   title =        "Strong {PUFs}: Models, Constructions, and Security Proofs",
   pages =        "79--96",
@@ -3252,11 +3252,11 @@ year =           1997,
 }
 
 @InCollection{SPYQYO10,
-  author =       "Fran{\c c}ois-Xavier Standaert and 
-                  Olivier Pereira and 
-                  Yu Yu and 
-                  Jean-Jacques Quisquater and 
-                  Moti Yung and 
+  author =       "Fran{\c c}ois-Xavier Standaert and
+                  Olivier Pereira and
+                  Yu Yu and
+                  Jean-Jacques Quisquater and
+                  Moti Yung and
                   Elisabeth Oswald",
   title =        "Leakage Resilient Cryptography in Practice",
   pages =        "99--134",
@@ -3264,10 +3264,10 @@ year =           1997,
 }
 
 @InCollection{AMSST10,
-  author =       "Frederik Armknecht and 
-                  Roel Maes and 
-                  Ahmad-Reza Sadeghi and 
-                  Berk Sunar and 
+  author =       "Frederik Armknecht and
+                  Roel Maes and
+                  Ahmad-Reza Sadeghi and
+                  Berk Sunar and
                   Pim Tuyls",
   title =        "Memory Leakage-Resilient Encryption Based on Physically Unclonable Functions",
   pages =        "135--164",
@@ -3275,7 +3275,7 @@ year =           1997,
 }
 
 @InCollection{TehSun10,
-  author =       "Mohammad Tehranipoor and 
+  author =       "Mohammad Tehranipoor and
                   Berk Sunar",
   title =        "Hardware Trojan Horses",
   pages =        "167--187",
@@ -3283,9 +3283,9 @@ year =           1997,
 }
 
 @InCollection{BGKN10,
-  author =       "Yoo-Jin Baek and 
-                  Vanessa Gratzer and 
-                  Sung-Hyun Kim and 
+  author =       "Yoo-Jin Baek and
+                  Vanessa Gratzer and
+                  Sung-Hyun Kim and
                   David Naccache",
   title =        "Extracting Unknown Keys from Unknown Algorithms Encrypting Unknown Fixed Messages and Returning No Results",
   pages =        "189--197",
@@ -3293,8 +3293,8 @@ year =           1997,
 }
 
 @InCollection{HamDanSun10,
-  author =       "Ghaith Hammouri and 
-                  Aykutlu Dana and 
+  author =       "Ghaith Hammouri and
+                  Aykutlu Dana and
                   Berk Sunar",
   title =        "License Distribution Protocols from Optical Media Fingerprints",
   pages =        "201--222",
@@ -3309,10 +3309,10 @@ year =           1997,
 }
 
 @InCollection{LBSPV10,
-  author =       "Yong Ki Lee and 
-                  Lejla Batina and 
-                  Dave Singel{\'e}e and 
-                  Bart Preneel and 
+  author =       "Yong Ki Lee and
+                  Lejla Batina and
+                  Dave Singel{\'e}e and
+                  Bart Preneel and
                   Ingrid Verbauwhede",
   title =        "Anti-counterfeiting, Untraceability and Other Security Challenges for {RFID} Systems: Public-Key-Based Protocols and Hardware",
   pages =        "237--257",
@@ -3320,7 +3320,7 @@ year =           1997,
 }
 
 @InCollection{UllVog10,
-  author =       "Markus Ullmann and 
+  author =       "Markus Ullmann and
                   Matthias V{\"o}geler",
   title =        "Contactless Security Token Enhanced Security by Using New Hardware Features in Cryptographic-Based Security Mechanisms",
   pages =        "259--279",
@@ -3328,8 +3328,8 @@ year =           1997,
 }
 
 @InCollection{SadVisWac10,
-  author =       "Ahmad-Reza Sadeghi and 
-                  Ivan Visconti and 
+  author =       "Ahmad-Reza Sadeghi and
+                  Ivan Visconti and
                   Christian Wachsmann",
   title =        "Enhancing {RFID} Security and Privacy by Physically Unclonable Functions",
   pages =        "281--305",
@@ -3337,8 +3337,8 @@ year =           1997,
 }
 
 @InCollection{DenChaSuh10,
-  author =       "Daniel Y. Deng and 
-                  Andrew H. Chan and 
+  author =       "Daniel Y. Deng and
+                  Andrew H. Chan and
                   G. Edward Suh",
   title =        "Authentication of Processor Hardware Leveraging Performance Limits in Detailed Simulations and Emulations",
   pages =        "309--329",
@@ -3353,9 +3353,9 @@ year =           1997,
 }
 
 @InCollection{DGLM10,
-  author =       "Lo{\"i}c Duflot and 
-                  Olivier Grumelard and 
-                  Olivier Levillain and 
+  author =       "Lo{\"i}c Duflot and
+                  Olivier Grumelard and
+                  Olivier Levillain and
                   Benjamin Morin",
   title =        "On the Limits of Hypervisor- and Virtual Machine Monitor-Based Isolation",
   pages =        "349--366",
@@ -3363,9 +3363,9 @@ year =           1997,
 }
 
 @InCollection{JKSS10,
-  author =       "Kimmo J{\"a}rvinen and 
-                  Vladimir Kolesnikov and 
-                  Ahmad-Reza Sadeghi and 
+  author =       "Kimmo J{\"a}rvinen and
+                  Vladimir Kolesnikov and
+                  Ahmad-Reza Sadeghi and
                   Thomas Schneider",
   title =        "Efficient Secure Two-Party Computation with Untrusted Hardware Tokens (Full Version)",
   pages =        "367--386",
@@ -3373,8 +3373,8 @@ year =           1997,
 }
 
 @InCollection{GuaAsiPet10,
-  author =       "Jorge Guajardo and 
-                  Muhammad Asim and 
+  author =       "Jorge Guajardo and
+                  Muhammad Asim and
                   Milan Petkovic",
   title =        "Towards Reliable Remote Healthcare Applications Using Combined Fuzzy Extraction",
   pages =        "387--407",
@@ -3382,10 +3382,10 @@ year =           1997,
 }
 
 @InCollection{SLLLB10,
-  author =       "Ionica Smeets and 
-                  Arjen K. Lenstra and 
-                  Lenstra, Jr., Hendrik W. and 
-                  L{\'a}szl{\'o} Lov{\'a}sz and 
+  author =       "Ionica Smeets and
+                  Arjen K. Lenstra and
+                  Lenstra, Jr., Hendrik W. and
+                  L{\'a}szl{\'o} Lov{\'a}sz and
                   Peter van Emde Boas",
   title =        "The History of the {LLL}-Algorithm",
   pages =        "1--17",
@@ -3400,7 +3400,7 @@ year =           1997,
 }
 
 @InCollection{ValVer10,
-  author =       "Brigitte Vall{\'e}e and 
+  author =       "Brigitte Vall{\'e}e and
                   Antonio Vera",
   title =        "Probabilistic Analyses of Lattice Reduction Algorithms",
   pages =        "71--143",
@@ -3443,7 +3443,7 @@ year =           1997,
 }
 
 @InCollection{AarEis10,
-  author =       "Karen Aardal and 
+  author =       "Karen Aardal and
                   Friedrich Eisenbrand",
   title =        "The {LLL} Algorithm and Integer Programming",
   pages =        "293--314",
@@ -3458,9 +3458,9 @@ year =           1997,
 }
 
 @InCollection{HHPW10,
-  author =       "Jeffrey Hoffstein and 
-                  Nick Howgrave-Graham and 
-                  Jill Pipher and 
+  author =       "Jeffrey Hoffstein and
+                  Nick Howgrave-Graham and
+                  Jill Pipher and
                   William Whyte",
   title =        "Practical Lattice-Based Cryptography: {NTRUEncrypt} and {NTRUSign}",
   pages =        "349--390",
@@ -3503,7 +3503,7 @@ year =           1997,
 }
 
 @InCollection{AnRab10,
-  author =       "Jee Hea An and 
+  author =       "Jee Hea An and
                   Tal Rabin",
   title =        "Security for Signcryption: The Two-User Model",
   pages =        "21--42",
@@ -3511,7 +3511,7 @@ year =           1997,
 }
 
 @InCollection{BaeSte10,
-  author =       "Joonsang Baek and 
+  author =       "Joonsang Baek and
                   Ron Steinfeld",
   title =        "Security for Signcryption: The Multi-User Model",
   pages =        "43--53",
@@ -3519,9 +3519,9 @@ year =           1997,
 }
 
 @InCollection{BLMQ10a,
-  author =       "Paulo S. L. M. Barreto and 
-                  Beno{\^i}t Libert and 
-                  Noel McCullagh and 
+  author =       "Paulo S. L. M. Barreto and
+                  Beno{\^i}t Libert and
+                  Noel McCullagh and
                   Jean-Jacques Quisquater",
   title =        "Signcryption Schemes Based on the Diffie-Hellman Problem",
   pages =        "57--69",
@@ -3529,9 +3529,9 @@ year =           1997,
 }
 
 @InCollection{BLMQ10b,
-  author =       "Paulo S. L. M. Barreto and 
-                  Beno{\^i}t Libert and 
-                  Noel McCullagh and 
+  author =       "Paulo S. L. M. Barreto and
+                  Beno{\^i}t Libert and
+                  Noel McCullagh and
                   Jean-Jacques Quisquater",
   title =        "Signcryption Schemes Based on Bilinear Maps",
   pages =        "71--97",
@@ -3539,7 +3539,7 @@ year =           1997,
 }
 
 @InCollection{DenMal10,
-  author =       "Alexander W. Dent and 
+  author =       "Alexander W. Dent and
                   John Malone-Lee",
   title =        "Signcryption Schemes Based on the {RSA} Problem",
   pages =        "99--117",
@@ -3561,7 +3561,7 @@ year =           1997,
 }
 
 @InCollection{PiePoi10,
-  author =       "Josef Pieprzyk and 
+  author =       "Josef Pieprzyk and
                   David Pointcheval",
   title =        "Parallel Signcryption",
   pages =        "175--192",
@@ -3583,7 +3583,7 @@ year =           1997,
 }
 
 @InCollection{CuiHan10,
-  author =       "Yang Cui and 
+  author =       "Yang Cui and
                   Goichiro Hanaoka",
   title =        "Applications of Signcryption",
   pages =        "241--256",
@@ -4251,7 +4251,7 @@ year =           1997,
 }
 
 @Book{NguVal10,
-  editor =       "Phong Q. Nguyen and 
+  editor =       "Phong Q. Nguyen and
                   Brigitte Vall{\'e}e",
   title =        "The {LLL} Algorithm - Survey and Applications",
   publisher =    springer,


### PR DESCRIPTION
This PR fixes the capture of my last name in the references for the FAEST signature scheme.

Also, it removes trailing whitespace from `crypto_misc.bib`. I can remove that from the PR if this is not desired.

Thanks for all the work!