### PR TITLE
Remove DCC entries from misc

### DIFF
--- a/crypto_misc.bib
+++ b/crypto_misc.bib
@@ -2221,44 +2221,6 @@
 }
 
 %------------------------------------------------------------------
-%               DESIGNS, CODES AND CRYPTOGRAPHY
-%------------------------------------------------------------------
-
-@Article{StiVan98,
-  author =       "Douglas R. Stinson and
-                  Tran van Trung",
-  title =        "Some New Results on Key Distribution Patterns and Broadcast Encryption",
-  journal =      "Designs, Codes and Cryptography",
-  year =         1998,
-  volume =       14,
-  number =       3,
-  pages =        "261--279",
-}
-
-@Article{Blackburn97,
-author =         "Simon R. Blackburn",
-title =          "A generalized rational interpolation problem and the solution of the {Welch-Berlekamp} key equation",
-journal =        "Designs, Codes and Cryptography",
-volume =         11,
-number =         3,
-pages =          "223--234",
-year =           1997,
-}
-
-@Article{DifVanWie92,
-  author =       "Whitfield Diffie and
-                  Paul C. van Oorschot and
-                  Michael J. Wiener",
-  title =        "Authentication and Authenticated Key Exchanges",
-  pages =        "107--125",
-  journal =      "Designs, Codes and Cryptography",
-  volume =       2,
-  number =       2,
-  month =        jun,
-  year =         1992,
-}
-
-%------------------------------------------------------------------
 %                ACM TRANSACTIONS ON COMPUTER SYSTEMS
 %------------------------------------------------------------------
 


### PR DESCRIPTION
These entries are duplicated, because all DCC articles are imported also in crypto_db (with DCC: prefix).