### PR TITLE
Update authors in NIST PQC Additional Digital Signature ROUND 2

### DIFF
--- a/crypto_misc.bib
+++ b/crypto_misc.bib
@@ -4,7 +4,7 @@
 
 % ============= Code-based Signatures
 @techreport{NISTPQC-ADD-R2:CROSS24,
-  author       = {Marco Baldi and Alessandro Barenghi and Sebastian Bitzer and Patrick Karl and Felice Manganiello and Alessio Pavoni and Gerardo Pelosi and Paolo Santini and Jonas Schupp and Freeman Slaughter and Antonia {Wachter-Zeh} and Violetta Weger},
+  author       = {Marco Baldi and Alessandro Barenghi and Michele Battagliola and Sebastian Bitzer and Marco Gianvecchio and Patrick Karl and Felice Manganiello and Alessio Pavoni and Gerardo Pelosi and Paolo Santini and Jonas Schupp and Edoardo Signorini and Freeman Slaughter and Antonia {Wachter-Zeh} and Violetta Weger},
   title        = {{CROSS} --- {Codes and Restricted Objects Signature Scheme}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2024,
@@ -12,7 +12,7 @@
 }
 
 @techreport{NISTPQC-ADD-R2:LESS24,
-  author       = {Marco Baldi and Alessandro Barenghi and Luke Beckwith and {Jean-Fran\c{c}ois} Biasse and Andre Esser and Kris Gaj and Kamyar Mohajerani and Gerardo Pelosi and Edoardo Persichetti and {Markku-Juhani} O. Saarinen and Paolo Santini and Robert Wallace},
+  author       = {Marco Baldi and Alessandro Barenghi and Luke Beckwith and {Jean-Fran\c{c}ois} Biasse and Tung Chou and Andre Esser and Kris Gaj and Patrick Karl and Kamyar Mohajerani and Gerardo Pelosi and Edoardo Persichetti and {Markku-Juhani} O. Saarinen and Paolo Santini and Robert Wallace and Floyd Zweydinger},
   title        = {{LESS} --- {Linear Equivalence Signature Scheme}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2024,
@@ -21,7 +21,7 @@
 
 % ============= Isogeny Signatures
 @techreport{NISTPQC-ADD-R2:SQIsign24,
-  author       = {Jorge {Chavez-Saab} and Maria {Corte-Real} Santos and Luca {De Feo} and Jonathan Komada Eriksen and Basil Hess and David Kohel and Antonin Leroux and Patrick Longa and Michael Meyer and Lorenz Panny and Sikhar Patranabis and Christophe Petit and Francisco {Rodr\'{i}guez Henr\'{i}quez} and Sina Schaeffler and Benjamin Wesolowski},
+  author       = {Marius A. Aardal and Gora Adj and Diego F. Aranha and Andrea Basso and Isaac Andrés {Canales Mart\'{i}nez} and Jorge {Ch\'{a}vez-Saab} and Maria {Corte-Real} Santos and Pierrick Dartois and Luca {De Feo} and Max Duparc and Jonathan Komada Eriksen and Tako Boris Fouotsa and D\'{e}cio Luiz Gazzoni Filho and Basil Hess and David Kohel and Antonin Leroux and Patrick Longa and Luciano Maino and Michael Meyer and Kohei Nakagawa and Hiroshi Onuki and Lorenz Panny and Sikhar Patranabis and Christophe Petit and Giacomo Pope and Krijn Reijnders and Damien Robert and Francisco {Rodr\'{i}guez Henr\'{i}quez} and Sina Schaeffler and Benjamin Wesolowski}, 
   title        = {{SQIsign}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2024,
@@ -39,7 +39,7 @@
 
 % ============= MPC-in-the-Head Signatures
 @techreport{NISTPQC-ADD-R2:Mirath24,
-  author       = {Nicolas Aragon and Magali Bardet and Lo\"{i}c Bidoux and {Jes\'{u}s-Javier} {Chi-Dom\'{i}nguez} and Victor Dyseryn and Thibauld Feneuil and Philippe Gaborit and Romaric Neveu and Matthieu Rivain and {Jean-Pierre} Tillich and Gora Adj and Luis {Rivera-Zamarripa} and Javier Verbel and Emanuele Bellini and Stefano Barbero and Andre Esser and Carlo Sanna and Floyd Zweydinger},
+  author       = {Gor Adj and Nicolas Aragon and Stefano Barbero and Magali Bardet and Emmanuele Bellini and Lo\"{i}c Bidoux and {Jes\'{u}s-Javier} {Chi-Dom\'{i}nguez} and Victor Dyseryn and Andre Esser and Thibauld Feneuil and Philippe Gaborit and Romaric Neveu and Matthieu Rivain and Luis {Rivera-Zamarripa} and Carlo Sanna and {Jean-Pierre} Tillich and Javier Verbel and Floyd Zweydinger}, 
   title        = {{Mirath (merger of {MIRA}/{MiRitH})}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2024,
@@ -47,7 +47,7 @@
 }
 
 @techreport{NISTPQC-ADD-R2:MQOM24,
-  author       = {Thibauld Feneuil and Matthieu Rivain},
+  author       = {Ryad Benadjila and Charles Bouillaguet and Thibauld Feneuil and Matthieu Rivain},
   title        = {{MQOM} --- {MQ on my Mind}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2024,
@@ -55,7 +55,7 @@
 }
 
 @techreport{NISTPQC-ADD-R2:PERK24,
-  author       = {Najwa Aaraj and Slim Bettaieb and Lo\"{i}c Bidoux and Alessandro Budroni and Victor Dyseryn and Andre Esser and Philippe Gaborit and Mukul Kulkarni and Victor Mateu and Marco Palumbi and Lucas Perin and {Jean-Pierre} Tillich},
+  author       = {Najwa Aaraj and Slim Bettaieb and Lo\"{i}c Bidoux and Alessandro Budroni and Victor Dyseryn and Andre Esser and Thibauld Feneuil and Philippe Gaborit and Mukul Kulkarni and Victor Mateu and Marco Palumbi and Lucas Perin and Matthieu Rivain and {Jean-Pierre} Tillich and Keita Xagawa}, 
   title        = {{PERK}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2024,
@@ -63,7 +63,7 @@
 }
 
 @techreport{NISTPQC-ADD-R2:RYDE24,
-  author       = {Nicolas Aragon and Magali Bardet and Lo\"{i}c Bidoux and {Jes\'{u}s-Javier} {Chi-Dom\'{i}nguez} and Victor Dyseryn and Thibauld Feneuil and Philippe Gaborit and Antoine Joux and Matthieu Rivain and {Jean-Pierre} Tillich and Adrien Vin\c{c}otte},
+  author       = {Nicolas Aragon and Magali Bardet and Lo\"{i}c Bidoux and {Jes\'{u}s-Javier} {Chi-Dom\'{i}nguez} and Victor Dyseryn and Thibauld Feneuil and Philippe Gaborit and Antoine Joux and Romaric Neveu and Matthieu Rivain and {Jean-Pierre} Tillich and Adrien Vin\c{c}otte},
   title        = {{RYDE}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2024,
@@ -71,7 +71,7 @@
 }
 
 @techreport{NISTPQC-ADD-R2:SDitH24,
-  author       = {Carlos {Aguilar-Melchor} and Thibauld Feneuil and Nicolas Gama and Shay Gueron and James Howe and David Joseph and Antoine Joux and Edoardo Persichetti and Tovohery H. Randrianarisoa and Matthieu Rivain and Dongze Yue},
+  author       = {Carlos {Aguilar Melchor} and Slim Bettaieb and Lo\"{i}c Bidoux and Thibauld Feneuil and Philippe Gaborit and Nicolas Gama and Shay Gueron and James Howe and Andreas H\"{u}lsing and David Joseph and Antoine Joux and Mukul Kulkarni and Edoardo Persichetti and Tovohery H. Randrianarisoa and Matthieu Rivain and Dongze Yue},
   title        = {{SDitH} --- {Syndrome Decoding in the Head}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2024,
@@ -88,7 +88,7 @@
 }
 
 @techreport{NISTPQC-ADD-R2:QR-UOV24,
-  author       = {Hiroki Furue and Yasuhiko Ikematsu and Fumitaka Hoshino and Tsuyoshi Takagi and Kan Yasuda and Toshiyuki Miyazawa and Tsunekazu Saito and Akira Nagai},
+  author       = {Rika Akiyama and Hiroki Furue and Yasuhiko Ikematsu and Fumitaka Hoshino and Koha Kinjo and Haruhisa Kosuge and Satoshi Nakamura and Shingo Orihara and Tsuyoshi Takagi and Kimihiro Yamakoshi},
   title        = {{QR-UOV}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2024,
@@ -96,7 +96,7 @@
 }
 
 @techreport{NISTPQC-ADD-R2:SNOVA24,
-  author       = {{Lih-Chung} Wang and {Chun-Yen} Chou and Jintai Ding and {Yen-Liang} Kuan and {Ming-Siou} Li and {Bo-Shu} Tseng and {Po-En} Tseng and {Chia-Chun} Wang},
+  author       = {{Lih-Chung} Wang and {Chun-Yen} Chou and Jintai Ding and {Yen-Liang} Kuan and Jan Adriaan Leegwater and {Ming-Siou} Li and {Bo-Shu} Tseng and {Po-En} Tseng and {Chia-Chun} Wang},
   title        = {{SNOVA}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2024,
@@ -113,7 +113,7 @@
 
 % ============= Symmetric-based Signatures
 @techreport{NISTPQC-ADD-R2:FAEST24,
-  author       = {Carsten Baum and Lennart Braun and Cyprien {Delpech de Saint Guilhem} and Michael Kloo{\ss} and Christian Majenz and Shibam Mukherjee and Emmanuela Orsini and Sebastian Ramacher and Christian Rechberger and Lawrence Roy and Peter Scholl},
+  author       = {Carsten Baum and Lennart Braun and Ward Beullens and Cyprien {Delpech de Saint Guilhem} and Michael Kloo{\ss} and Christian Majenz and Shibam Mukherjee and Emmanuela Orsini and Sebastian Ramacher and Christian Rechberger and Lawrence Roy and Peter Scholl},
   title        = {{FAEST}},
   institution  = {{N}ational {I}nstitute of {S}tandards and {T}echnology},
   year         = 2024,


### PR DESCRIPTION
Update authors by reflecting Tweaks in 2025-03-04. 