### PR TITLE
Added ToSC 2024 (issues 2-4)

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -1,3 +1,6 @@
+* 2025-05-28
+ToSC 2024 (Issues 2-4)
+
 * 2025-05-21
 Added PKC 2025, CiC vol 1, nr 4 and vol 2, nr 1
 


### PR DESCRIPTION
Added the remaining issues (2-4) of ToSC 2024.

This is my first addition to cryptobib, so I hope I did everything correctly. ToSC is a relatively easy addition because there's no conference data to add, so it should be fine.

I could not run the tests, though, since I'm working with NixOS and didn't manage to make the development shell find the pcre library (the one you write about in the README). If you would be open to adding a nix flake to the development repo at some point, I might look into this some more when I have the time.